### PR TITLE
Add binary specification

### DIFF
--- a/UBRE.md
+++ b/UBRE.md
@@ -2,15 +2,17 @@
 
 ***WARNING** *This is still alpha stage - expect breaking changes*
 
-**Ubre is a small json spec for supporting pub/sub & request/response message passing.**
+**Ubre is a small spec for supporting pub/sub & request/response message passing.**
 
-It can be used on any kind of connection that supports sending / receiving json messages, but was created with websockets in mind. It should be easy to use for communicating through iframes, service workers and similar avenues.
+It can be used on any kind of connection that supports sending / receiving text/binary messages, but was created with websockets in mind. It should be easy to use for communicating through iframes, service workers and similar avenues.
+
+The design is simple to nest recursively to create tunnels/proxies through UBRE itself.
 
 It is not concerned with deliverability or connection management, but is intended simply as a comman format for req/res and pub/sub messaging.
 
-You can find an opinionated implementation of UBRE in javascript which can be used on the server, and in the browser. 
+You can find an implementation of UBRE in javascript which can be used on the server, and in the browser. 
 
-## Message Formats
+## JSON Message Format
 
 ### pub / sub
 
@@ -73,3 +75,29 @@ Used to subscribe / publish. The handling of subscriptions according to the name
     ["body": "some fail data"]
 }
 ```
+
+## Binary Message Format
+
+The binary message format consists of a header with the message type(uint8), topic length(uint16) and body length(uint32) in network byte order (big endian - most significant byte first). Then comes the topic, and the body. If the body length is 0 no body is included. If the body length is -1 the body is expected to be streaming, and data should be read until the message ends.
+
+The topic format or body format is not defined by the protocol and is completely up to the user how to encode/decode.
+
+The message types are as follows:
+
+| Type      | ASCII | Hex  | Decimal |
+|-----------|-------|------|---------|
+| Subscribe | S     | 0x53 | 83      |
+| Publish   | P     | 0x50 | 80      |
+| Request   | R     | 0x52 | 82      |
+| success   | s     | 0x73 | 115     |
+| fail      | f     | 0x63 | 102     |
+
+That means a complete message looks like this:
+
+| Part         | Length | Content               |
+|--------------|--------|-----------------------|
+| Type         | uint8  | S \| P \| R \| s \| f |
+| Name length  | uint16 | length                |
+| Name content | ...    | byte(name length)     |
+| Body length  | uint32 | 0 \| -1 \| length     |
+| Body content | ...    | byte(body length)     |

--- a/UBRE.md
+++ b/UBRE.md
@@ -98,6 +98,6 @@ That means a complete message looks like this:
 |--------------|--------|-----------------------|
 | Type         | uint8  | S \| P \| R \| s \| f |
 | Name length  | uint16 | length                |
-| Name content | ...    | byte(name length)     |
 | Body length  | uint32 | 0 \| -1 \| length     |
+| Name content | ...    | byte(name length)     |
 | Body content | ...    | byte(body length)     |


### PR DESCRIPTION
UBRE fits quite easily into a simple binary format, which would also allow a streaming body. 